### PR TITLE
Secrets Override Fixes

### DIFF
--- a/src/secretManager.ts
+++ b/src/secretManager.ts
@@ -6,9 +6,14 @@ export class SecretManager {
   private fullSecretKeys?: RegExp[];
 
   constructor(config: SecretManagerConfig) {
-    this.secretKeys = config.secretKeys;
     this.deepSecretKeys = config.deepSecretKeys;
     this.fullSecretKeys = config.fullSecretKeys;
+
+    if (!config.secretKeys && (config.deepSecretKeys || config.fullSecretKeys)) {
+      this.secretKeys = [];
+    } else {
+      this.secretKeys = config.secretKeys;
+    }
   }
 
   /**
@@ -48,7 +53,7 @@ export class SecretManager {
     if (!this.fullSecretKeys) {
       return false;
     }
-    
+
     return SecretManager.valueMatchesAnyRegexValue(key, this.fullSecretKeys);
   }
 

--- a/tests/unit/secretManager.spec.ts
+++ b/tests/unit/secretManager.spec.ts
@@ -11,6 +11,35 @@ describe('NewSecretManager', () => {
     expect(secretManager.isFullSecretKey('qux')).toBe(false);
   });
 
+  it('Should not consider all values secret if deepSecretKeys or fullSecretKeys are provided', () => {
+    // deep secret
+    const deepSecretManager = new SecretManager({
+      deepSecretKeys: [/foo/]
+    });
+    expect(deepSecretManager.isSecretKey('foo')).toBe(false);
+    expect(deepSecretManager.isSecretKey('bar')).toBe(false);
+    expect(deepSecretManager.isDeepSecretKey('foo')).toBe(true);
+
+    // full secret
+    const fullSecretManager = new SecretManager({
+      fullSecretKeys: [/foo/]
+    });
+    expect(fullSecretManager.isSecretKey('foo')).toBe(false);
+    expect(fullSecretManager.isSecretKey('bar')).toBe(false);
+    expect(fullSecretManager.isFullSecretKey('foo')).toBe(true);
+
+    // both
+    const combinedSecretManager = new SecretManager({
+      fullSecretKeys: [/foo/],
+      deepSecretKeys: [/bar/]
+    });
+    expect(combinedSecretManager.isSecretKey('foo')).toBe(false);
+    expect(combinedSecretManager.isSecretKey('bar')).toBe(false);
+    expect(combinedSecretManager.isSecretKey('hello')).toBe(false);
+    expect(combinedSecretManager.isFullSecretKey('foo')).toBe(true);
+    expect(combinedSecretManager.isDeepSecretKey('bar')).toBe(true);
+  });
+
   it('Returns true for secretKeys that match', () => {
     const secretManager = new SecretManager({
       secretKeys: [/foo/, /^pass/]


### PR DESCRIPTION
Set secretKeys to empty array when fullSecretKeys or deepSecretKeys are specified.