### PR TITLE
FR-33: Do not throw exceptions on non-JSON input

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In many instances, redaction of sensitive data from log output is fairly straigh
 If this object is placed in a data set with many others, and only some of these objects contain PII, redaction becomes quite troublesome. One could redact all `value` fields from these objects - but this merely renders the log output useless for debugging or tracing, as all values are now redacted. The value of the `name` field determines whether or not the `value` field should be redacted. I often found myself writing custom logic to make this determination, which led to brittle code that was difficult to maintain. In the end I decided to write a new, highly configurable plug-and-play solution that could redact sensitive data in various manners while requiring only minor configuration tweaks. Enter FieldRedactor!
 
 ## Basic Usage
-Basic usage of the FieldRedactor is straightforward but not recommended. Object redaction can be performed either in-place or return the redacted object:
+Basic usage of the FieldRedactor is straightforward but not recommended. Object redaction can be performed either in-place or return the redacted object. If redactor is given a string, primitive, Date, function, or null/undefined value then it returns the value without modification.
 
 ```typescript
 import { FieldRedactor } from 'field-redactor';
@@ -27,14 +27,17 @@ const fieldRedactor = new FieldRedactor();
 
 // return redacted result
 const result = await fieldRedactor.redact(myJsonObject);
+const primitiveResult = await fieldRedactor.redact("foobar");
 console.log(myJsonObject); // { foo: "bar", fizz: null }
 console.log(result); // { foo: "REDACTED", fizz: null }
+console.log(primitiveResult); // "foobar"
 
 // redact in place
 await fieldRedactor.redactInPlace(myJsonObject);
 console.log(myJsonObject); // { foo: "REDACTED", fizz: null }
 ```
 > **Note:** `null` and `undefined` values are not redacted by default.
+> **Note:** `null`, `undefined`, `string`, `Date`, `Function`, and primitive value inputs are completely ignored.
 
 
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -18,13 +18,3 @@ export class FieldRedactorConfigurationError extends FieldRedactorError {
     this.name = 'FieldRedactorConfigurationError';
   }
 }
-
-/**
- * Error thrown when the input value to the FieldRedactor fails validation, such as not being a JSON object.
- */
-export class FieldRedactorValidationError extends FieldRedactorError {
-  constructor(message: string) {
-    super(message);
-    this.name = 'FieldRedactorValidationError';
-  }
-}

--- a/src/fieldRedactor.ts
+++ b/src/fieldRedactor.ts
@@ -4,7 +4,7 @@ import { ObjectRedactor } from './objectRedactor';
 import { PrimitiveRedactor } from './primitiveRedactor';
 import { SecretManager } from './secretManager';
 import { CustomObjectManager } from './customObjectManager';
-import { FieldRedactorError, FieldRedactorValidationError } from './errors';
+import { FieldRedactorError } from './errors';
 
 /**
  * FieldRedactor is a highly customizable JSON object field redactor. It conditionally redacts fields based on
@@ -41,7 +41,8 @@ export class FieldRedactor {
   /**
    * Conditionally redacts fields in the JSON object based on the configuration provided in the constructor and returns the
    * redacted result.
-   * @param value The JSON value to redact.
+   * If the value is a primitive, undefined, or date, returns the value as-is.
+   * @param value The JSON value to redact. If primitive it will be resolved as-is.
    * @returns The redacted JSON object.
    */
   public async redact(value: any): Promise<any> {
@@ -51,10 +52,15 @@ export class FieldRedactor {
 
   /**
    * Conditionally redacts fields in the JSON object in place based on the configuration provided in the constructor.
-   * @param value The JSON value to redact in place.
+   * If the value is a primitive, undefined, or date, returns the value as-is.
+   * @param value The JSON value to redact in place. If primitive it will be resolved as-is.
+   * @returns The redacted JSON object.
    */
   public async redactInPlace(value: any): Promise<void> {
-    this.validateInput(value);
+    if (this.isPrimitiveOrUndefined(value)) {
+      return value;
+    }
+
     try {
       return this.objectRedactor.redactInPlace(value);
     } catch (e: any) {
@@ -62,9 +68,7 @@ export class FieldRedactor {
     }
   }
 
-  private validateInput(value: any) {
-    if (!value || typeof value !== 'object' || value instanceof Date) {
-      throw new FieldRedactorValidationError('Input value must be a JSON object');
-    }
+  private isPrimitiveOrUndefined(value: any) {
+    return !value || typeof value !== 'object' || value instanceof Date;
   }
 }

--- a/tests/unit/fieldRedactor.spec.ts
+++ b/tests/unit/fieldRedactor.spec.ts
@@ -3,7 +3,7 @@ import { PrimitiveRedactor } from '../../src/primitiveRedactor';
 import { SecretManager } from '../../src/secretManager';
 import { CustomObjectManager } from '../../src/customObjectManager';
 import { ObjectRedactor } from '../../src/objectRedactor';
-import { FieldRedactorValidationError } from '../../src/errors';
+import { FieldRedactorError } from '../../src/errors';
 jest.mock('../../src/primitiveRedactor');
 jest.mock('../../src/secretManager');
 jest.mock('../../src/customObjectManager');
@@ -74,32 +74,18 @@ describe('FieldRedactor', () => {
       expect(argument).toEqual(input);
     });
 
-    it('Should throw an exception on invalid input', async () => {
+    it('Should return undefined, null, Date, or non-primitive input as-is', async () => {
+      const func = () => {};
+      const date = new Date();
       const fieldRedactor = new FieldRedactor();
-      expect(() => fieldRedactor.redact(null)).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redact(undefined)).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redact('foo')).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redact(1)).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redact(false)).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redact(true)).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redact(new Date())).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redact(() => {})).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
+      expect(await fieldRedactor.redact(undefined)).toBe(undefined);
+      expect(await fieldRedactor.redact(null)).toBe(null);
+      expect(await fieldRedactor.redact(1)).toBe(1);
+      expect(await fieldRedactor.redact(true)).toBe(true);
+      expect(await fieldRedactor.redact(false)).toBe(false);
+      expect(await fieldRedactor.redact(date)).toEqual(date);
+      expect(await fieldRedactor.redact(func)).toBe(func);
+      expect(await fieldRedactor.redact('foo')).toBe('foo');
     });
 
     it('Should wrap any thrown exceptions in a FieldRedactorError', async () => {
@@ -109,9 +95,7 @@ describe('FieldRedactor', () => {
       mockObjectRedactor.redactInPlace.mockImplementation(async () => {
         throw new Error(errorText);
       });
-      expect(() => fieldRedactor.redactInPlace({ foo: 'bar' })).rejects.toThrow(
-        new FieldRedactorValidationError(errorText)
-      );
+      expect(() => fieldRedactor.redactInPlace({ foo: 'bar' })).rejects.toThrow(new FieldRedactorError(errorText));
     });
   });
 
@@ -126,31 +110,17 @@ describe('FieldRedactor', () => {
     });
 
     it('Should throw an exception on invalid input', async () => {
+      const func = () => {};
+      const date = new Date();
       const fieldRedactor = new FieldRedactor();
-      expect(() => fieldRedactor.redactInPlace(null)).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redactInPlace(undefined)).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redactInPlace('foo')).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redactInPlace(1)).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redactInPlace(false)).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redactInPlace(true)).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redactInPlace(new Date())).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
-      expect(() => fieldRedactor.redactInPlace(() => {})).rejects.toThrow(
-        new FieldRedactorValidationError('Input value must be a JSON object')
-      );
+      expect(await fieldRedactor.redactInPlace(undefined)).toBe(undefined);
+      expect(await fieldRedactor.redactInPlace(null)).toBe(null);
+      expect(await fieldRedactor.redactInPlace(1)).toBe(1);
+      expect(await fieldRedactor.redactInPlace(true)).toBe(true);
+      expect(await fieldRedactor.redactInPlace(false)).toBe(false);
+      expect(await fieldRedactor.redactInPlace(date)).toBe(date);
+      expect(await fieldRedactor.redactInPlace(func)).toBe(func);
+      expect(await fieldRedactor.redactInPlace('foo')).toBe('foo');
     });
 
     it('Should wrap any thrown exceptions in a FieldRedactorError', async () => {
@@ -160,9 +130,7 @@ describe('FieldRedactor', () => {
       mockObjectRedactor.redactInPlace.mockImplementation(async () => {
         throw new Error(errorText);
       });
-      expect(() => fieldRedactor.redactInPlace({ foo: 'bar' })).rejects.toThrow(
-        new FieldRedactorValidationError(errorText)
-      );
+      expect(() => fieldRedactor.redactInPlace({ foo: 'bar' })).rejects.toThrow(new FieldRedactorError(errorText));
     });
   });
 });


### PR DESCRIPTION
Allow non-json input to be returned as-is to simplify common usage code-flows.

Ticket: https://github.com/mologna/field-redactor/issues/33